### PR TITLE
feat(user): 유저 도메인, 유저 정보 및 팔로우/언팔로우 관리 로직 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ version = '0.0.1-SNAPSHOT'
 
 java {
 	toolchain {
-		languageVersion = JavaLanguageVersion.of(23)
+		languageVersion = JavaLanguageVersion.of(17)
 	}
 }
 

--- a/src/main/java/com/app/flashgram/user/domain/User.java
+++ b/src/main/java/com/app/flashgram/user/domain/User.java
@@ -1,0 +1,96 @@
+package com.app.flashgram.user.domain;
+
+import java.util.Objects;
+
+/**
+ * 유저 도메인 객체
+ */
+public class User {
+
+    private final Long id;
+    private final UserInfo info;
+    private final UserRelationCounter followingCount;
+    private final UserRelationCounter followerCounter;
+
+    /**
+     * 유저 도메인 객체 생성
+     *
+     * @param id       유저 식별자
+     * @param userInfo 유저 정보 값 객체
+     */
+    public User(Long id, UserInfo userInfo, UserRelationCounter followingCount, UserRelationCounter followerCounter) {
+        this.id = id;
+        this.info = userInfo;
+        this.followingCount = followingCount;
+        this.followerCounter = followerCounter;
+    }
+
+    /**
+     * 지정된 유저 팔로우
+     * 팔로우 시 자신의 팔로잉 수와 대상 유저의 팔로워 수가 증가
+     *
+     * @param targetUser 팔로우할 대상 유저
+     * @throws IllegalArgumentException 자기 자신을 팔로우하려는 경우
+     */
+    public void follow(User targetUser) {
+        if (this.equals(targetUser)) {
+            throw new IllegalArgumentException("자신을 팔로우 할 수 없습니다.");
+        }
+
+        followingCount.increase();
+        targetUser.increaseFollowerCount();
+    }
+
+    /**
+     * 지정된 유저 언팔로우
+     * 언팔로우 시 자신의 팔로잉 수와 대상 유저의 팔로워 수가 감소
+     *
+     * @param targetUser 언팔로우할 대상 유저
+     * @throws IllegalArgumentException 자기 자신을 언팔로우하려는 경우
+     */
+    public void unfollow(User targetUser) {
+        if (this.equals(targetUser)) {
+            throw new IllegalArgumentException("자신을 언팔로우 할 수 없습니다.");
+        }
+
+        followingCount.decrease();
+        targetUser.decreaseFollowerCount();
+    }
+
+    private void increaseFollowerCount() {
+        followerCounter.increase();
+    }
+
+    private void decreaseFollowerCount() {
+        followerCounter.decrease();
+    }
+
+    /**
+     * 유저 식별자 값을 기준으로 동일성을 비교
+     * 두 유저 객체의 식별자가 같다면 같은 사용자로 판단
+     *
+     * @param o 비교 대상 객체
+     * @return 같은 식별자를 가진 유저인 경우 true
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        User user = (User) o;
+        return Objects.equals(id, user.id);
+    }
+
+    /**
+     * 유저의 식별자를 기반으로 해시값을 생성
+     *
+     * @return 유저 식별자의 해시값
+     */
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(id);
+    }
+}

--- a/src/main/java/com/app/flashgram/user/domain/UserInfo.java
+++ b/src/main/java/com/app/flashgram/user/domain/UserInfo.java
@@ -1,0 +1,27 @@
+package com.app.flashgram.user.domain;
+
+/**
+ * 유저의 기본 정보를 표현하는 값 객체
+ */
+public class UserInfo {
+
+    private final String name;
+    private final String profileImgUrl;
+
+    /**
+     * 유저 정보 값 객체를 생성
+     * 이름은 필수값, null이나 빈 문자열이 입력되면 예외
+     *
+     * @param name          유저 이름
+     * @param profileImgUrl 프로필 이미지 URL
+     * @throws IllegalArgumentException 이름이 null이거나 빈 문자열인 경우
+     */
+    public UserInfo(String name, String profileImgUrl) {
+        if (name == null || name.isEmpty()) {
+            throw new IllegalArgumentException("이름은 null이거나 빈 문자열일 수 없습니다.");
+        }
+
+        this.name = name;
+        this.profileImgUrl = profileImgUrl;
+    }
+}

--- a/src/main/java/com/app/flashgram/user/domain/UserRelationCounter.java
+++ b/src/main/java/com/app/flashgram/user/domain/UserRelationCounter.java
@@ -1,0 +1,21 @@
+package com.app.flashgram.user.domain;
+
+public class UserRelationCounter {
+
+    private int count;
+
+    public UserRelationCounter() {
+        this.count = 0;
+    }
+
+    public void increase() {
+        this.count++;
+    }
+
+    public void decrease() {
+        if (this.count <= 0) {
+            return;
+        }
+        this.count--;
+    }
+}


### PR DESCRIPTION
- User 도메인 생성: 유저 정보 및 팔로잉, 팔로워 수를 관리
- UserInfo: 유저의 기본 정보 관리 (이름, 프로필 이미지)
- UserRelationCounter: 팔로잉, 팔로워 수를 관리하는 카운터 클래스 추가
- 팔로우/언팔로우 기능 구현: 자신의 팔로잉 수와 대상 유저의 팔로워 수 변경
- 예외 처리: 자기 자신을 팔로우/언팔로우 할 수 없음