### PR TITLE
feat(comment): 댓글 도메인 및 내용 유효성 검사 로직 구현

### DIFF
--- a/src/main/java/com/app/flashgram/post/domain/comment/Comment.java
+++ b/src/main/java/com/app/flashgram/post/domain/comment/Comment.java
@@ -1,0 +1,43 @@
+package com.app.flashgram.post.domain.comment;
+
+import com.app.flashgram.post.domain.Post;
+import com.app.flashgram.user.domain.User;
+
+/**
+ * 댓글 도메인 객체
+ */
+public class Comment {
+
+    private final Long id;
+    private final Post post;
+    private final User author;
+    private final String content;
+
+    /**
+     * 게시글 도메인 객체를 생성
+     *
+     * @param id      댓글 식별자
+     * @param post    게시글
+     * @param author  댓글 작성자
+     * @param content 댓글 내용
+     * @throws IllegalArgumentException 작성자, 게시글, 댓글 내용이 null인 경우
+     */
+    public Comment(Long id, Post post, User author, String content) {
+        if (author == null) {
+            throw new IllegalArgumentException("작성자는 null일 수 없습니다.");
+        }
+
+        if (post == null) {
+            throw new IllegalArgumentException("게시글은 null일 수 없습니다.");
+        }
+
+        if (content == null) {
+            throw new IllegalArgumentException("댓글 내용은 null일 수 없습니다.");
+        }
+
+        this.id = id;
+        this.post = post;
+        this.author = author;
+        this.content = content;
+    }
+}

--- a/src/main/java/com/app/flashgram/post/domain/content/CommentContent.java
+++ b/src/main/java/com/app/flashgram/post/domain/content/CommentContent.java
@@ -1,0 +1,23 @@
+package com.app.flashgram.post.domain.content;
+
+public class CommentContent extends Content {
+
+    public static final int MIN_COMMENT_LENGTH = 5;
+    public static final int MAX_COMMENT_LENGTH = 300;
+
+    public CommentContent(String content) {
+        super(content);
+    }
+
+    @Override
+    public void checkText(String content) {
+        if (content == null || content.isEmpty()) {
+            throw new IllegalArgumentException("댓글이 비어 있거나 null일 수 없습니다.");
+        }
+
+        if (content.length() < MIN_COMMENT_LENGTH || content.length() > MAX_COMMENT_LENGTH) {
+            throw new IllegalArgumentException("댓글의 길이가 유효한 범위(최소 " + MIN_COMMENT_LENGTH + "자, 최대 " + MAX_COMMENT_LENGTH + "자) 내에 있지 않습니다.");
+        }
+    }
+
+}

--- a/src/main/java/com/app/flashgram/post/domain/content/PostContent.java
+++ b/src/main/java/com/app/flashgram/post/domain/content/PostContent.java
@@ -5,6 +5,7 @@ package com.app.flashgram.post.domain.content;
  * 게시글 내용은 최소 5자, 최대 1000자
  */
 public class PostContent extends Content {
+
     private static final int MIN_POST_LENGTH = 5;
     private static final int MAX_POST_LENGTH = 1000;
 
@@ -27,7 +28,7 @@ public class PostContent extends Content {
     @Override
     protected void checkText(String contentText) {
         if (contentText == null ||contentText.isEmpty()) {
-            throw new IllegalArgumentException("내용이 비어 있거나 null일 수 없습니다.");
+            throw new IllegalArgumentException("내용은 비어 있거나 null일 수 없습니다.");
         }
 
         if (contentText.length() < MIN_POST_LENGTH || contentText.length() > MAX_POST_LENGTH) {


### PR DESCRIPTION
- Comment: 댓글 작성자 검증 로직
- CommentContent: 댓글 내용의 길이 및 null/빈 문자열 검증 추가 (최소 5자, 최대 300자)