### PR TITLE
feat(post): 게시글 피드 조회 기능 구현

### DIFF
--- a/src/main/java/com/app/flashgram/post/repository/CommentRepositoryImpl.java
+++ b/src/main/java/com/app/flashgram/post/repository/CommentRepositoryImpl.java
@@ -1,9 +1,11 @@
 package com.app.flashgram.post.repository;
 
 import com.app.flashgram.post.appication.interfaces.CommentRepository;
+import com.app.flashgram.post.domain.Post;
 import com.app.flashgram.post.domain.comment.Comment;
 import com.app.flashgram.post.repository.entity.comment.CommentEntity;
 import com.app.flashgram.post.repository.jpa.JpaCommentRepository;
+import com.app.flashgram.post.repository.jpa.JpaPostRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -17,6 +19,7 @@ import org.springframework.stereotype.Repository;
 public class CommentRepositoryImpl implements CommentRepository {
 
     private final JpaCommentRepository jpaCommentRepository;
+    private final JpaPostRepository jpaPostRepository;
 
     /**
      * 댓글을 저장하거나 업데이트
@@ -28,6 +31,8 @@ public class CommentRepositoryImpl implements CommentRepository {
     @Override
     @Transactional
     public Comment save(Comment comment) {
+
+        Post targetPost = comment.getPost();
         CommentEntity commentEntity = new CommentEntity(comment);
 
         if (comment.getId() != null) {
@@ -35,6 +40,7 @@ public class CommentRepositoryImpl implements CommentRepository {
         }
 
         commentEntity = jpaCommentRepository.save(commentEntity);
+        jpaPostRepository.increaseCommentCount(targetPost.getId());
 
         return commentEntity.toComment();
     }

--- a/src/main/java/com/app/flashgram/post/repository/PostRepositoryImpl.java
+++ b/src/main/java/com/app/flashgram/post/repository/PostRepositoryImpl.java
@@ -4,6 +4,7 @@ import com.app.flashgram.post.appication.interfaces.PostRepository;
 import com.app.flashgram.post.domain.Post;
 import com.app.flashgram.post.repository.entity.post.PostEntity;
 import com.app.flashgram.post.repository.jpa.JpaPostRepository;
+import com.app.flashgram.post.repository.post_queue.UserPostQueueCommandRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -17,6 +18,7 @@ import org.springframework.stereotype.Repository;
 public class PostRepositoryImpl implements PostRepository {
 
     private final JpaPostRepository jpaPostRepository;
+    private final UserPostQueueCommandRepository commandRepository;
 
     /**
      * Post 객체 저장하거나 업데이트
@@ -35,10 +37,10 @@ public class PostRepositoryImpl implements PostRepository {
             return postEntity.toPost();
         }
 
-        PostEntity entity = new PostEntity(post);
-        entity = jpaPostRepository.save(entity);
+        postEntity = jpaPostRepository.save(postEntity);
+        commandRepository.publishPost(postEntity);
 
-        return entity.toPost();
+        return postEntity.toPost();
     }
 
     @Override

--- a/src/main/java/com/app/flashgram/post/repository/entity/post/PostEntity.java
+++ b/src/main/java/com/app/flashgram/post/repository/entity/post/PostEntity.java
@@ -19,6 +19,7 @@ import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
 
 @Entity
 @Table(name = "fg_post")
@@ -41,6 +42,9 @@ public class PostEntity extends TimeBaseEntity {
     private PostPublicationState state;
 
     private Integer likeCount;
+
+    @ColumnDefault("0")
+    private int commentCount;
 
     public PostEntity(Post post) {
         this.id = post.getId();

--- a/src/main/java/com/app/flashgram/post/repository/entity/post/UserPostQueueEntity.java
+++ b/src/main/java/com/app/flashgram/post/repository/entity/post/UserPostQueueEntity.java
@@ -1,0 +1,31 @@
+package com.app.flashgram.post.repository.entity.post;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "fg_user_post_queue")
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class UserPostQueueEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private Long userId;
+    private Long postId;
+    private Long authorId;
+
+    public UserPostQueueEntity(Long userId, Long postId, Long authorId) {
+        this.userId = userId;
+        this.postId = postId;
+        this.authorId = authorId;
+    }
+}

--- a/src/main/java/com/app/flashgram/post/repository/jpa/JpaPostRepository.java
+++ b/src/main/java/com/app/flashgram/post/repository/jpa/JpaPostRepository.java
@@ -1,6 +1,7 @@
 package com.app.flashgram.post.repository.jpa;
 
 import com.app.flashgram.post.repository.entity.post.PostEntity;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -37,4 +38,25 @@ public interface JpaPostRepository extends JpaRepository<PostEntity, Long> {
             + "p.updAt = now() "
             + "WHERE p.id = :#{#postEntity.getId()}")
     void updateLikeCount(PostEntity postEntity);
+
+    /**
+     * 게시물의 댓글 수를 1 증가시키고 수정 시간 업데이트
+     *
+     * @param id 댓글 수를 증가시킬 게시물의 ID
+     */
+    @Modifying
+    @Query(value = "UPDATE PostEntity p "
+            + "SET p.commentCount = p.commentCount + 1, "
+            + "p.updAt = now() "
+            + "WHERE p.id = :id")
+    void increaseCommentCount(Long id);
+
+    /**
+     * 특정 작성자의 모든 게시물 ID를 조회
+     *
+     * @param authorId 게시물을 조회할 작성자의 ID
+     * @return 해당 작성자가 작성한 모든 게시물의 ID 리스트
+     */
+    @Query("SELECT p.id FROM PostEntity p WHERE p.author.id = :authorId")
+    List<Long> findAllPostIdByAuthorId(Long authorId);
 }

--- a/src/main/java/com/app/flashgram/post/repository/jpa/JpaUserPostQueueRepository.java
+++ b/src/main/java/com/app/flashgram/post/repository/jpa/JpaUserPostQueueRepository.java
@@ -1,0 +1,9 @@
+package com.app.flashgram.post.repository.jpa;
+
+import com.app.flashgram.post.repository.entity.post.UserPostQueueEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JpaUserPostQueueRepository extends JpaRepository<UserPostQueueEntity, Long> {
+
+    void deleteAllByUserIdAndAuthorId(Long userId, Long targetId);
+}

--- a/src/main/java/com/app/flashgram/post/repository/post_queue/UserPostQueueCommandRepository.java
+++ b/src/main/java/com/app/flashgram/post/repository/post_queue/UserPostQueueCommandRepository.java
@@ -1,0 +1,32 @@
+package com.app.flashgram.post.repository.post_queue;
+
+import com.app.flashgram.post.repository.entity.post.PostEntity;
+
+/**
+ * 유저의 게시물 큐를 관리하는 Repository 인터페이스
+ */
+public interface UserPostQueueCommandRepository {
+
+    /**
+     * 새로운 게시물을 팔로워들의 피드 큐에 발행
+     *
+     * @param postEntity 발행할 게시물 엔티티
+     */
+    void publishPost(PostEntity postEntity);
+
+    /**
+     * 팔로우한 유저의 게시물들을 현재 유저의 피드 큐에 저장
+     *
+     * @param userId 현재 유저 ID
+     * @param targetId 팔로우한 유저 ID
+     */
+    void saveFollowPost(Long userId, Long targetId);
+
+    /**
+     * 언팔로우한 유저의 게시물들을 현재 유저의 피드 큐에서 제거
+     *
+     * @param userId 현재 유저 ID
+     * @param targetId 언팔로우한 유저 ID
+     */
+    void deleteUnfollowPost(Long userId, Long targetId);
+}

--- a/src/main/java/com/app/flashgram/post/repository/post_queue/UserPostQueueCommandRepositoryImpl.java
+++ b/src/main/java/com/app/flashgram/post/repository/post_queue/UserPostQueueCommandRepositoryImpl.java
@@ -1,0 +1,72 @@
+package com.app.flashgram.post.repository.post_queue;
+
+import com.app.flashgram.post.repository.entity.post.PostEntity;
+import com.app.flashgram.post.repository.entity.post.UserPostQueueEntity;
+import com.app.flashgram.post.repository.jpa.JpaPostRepository;
+import com.app.flashgram.post.repository.jpa.JpaUserPostQueueRepository;
+import com.app.flashgram.user.repository.entity.UserEntity;
+import com.app.flashgram.user.repository.jpa.JpaUserRelationRepository;
+import jakarta.transaction.Transactional;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+/**
+ * 유저의 게시물 큐를 관리하는 Repository 구현체
+ */
+@Repository
+@RequiredArgsConstructor
+public class UserPostQueueCommandRepositoryImpl implements UserPostQueueCommandRepository {
+
+    private final JpaPostRepository jpaPostRepository;
+    private final JpaUserRelationRepository jpaUserRelationRepository;
+    private final JpaUserPostQueueRepository jpaUserPostQueueRepository;
+
+    /**
+     * 작성자의 모든 팔로워들의 피드 큐에 발행
+     * 팔로워 목록을 조회하고 각 팔로워의 큐에 게시물 추가
+     *
+     * @param postEntity 발행할 게시물 엔티티
+     */
+    @Override
+    @Transactional
+    public void publishPost(PostEntity postEntity) {
+        UserEntity userEntity = postEntity.getAuthor();
+
+        List<Long> followers = jpaUserRelationRepository.findFollowers(userEntity.getId());
+        List<UserPostQueueEntity> userPostQueueEntityList = followers.stream()
+                                                                     .map(userId -> new UserPostQueueEntity(userId, postEntity.getId(), userEntity.getId()))
+                                                                     .toList();
+
+        jpaUserPostQueueRepository.saveAll(userPostQueueEntityList);
+    }
+
+    /**
+     * 팔로우한 유저의 모든 게시물을 현재 유저의 피드 큐에 저장
+     * 팔로우한 유저의 모든 게시물 ID를 조회하고 현재 유저의 큐에 추가
+     *
+     * @param userId 현재 유저 ID
+     * @param targetId 팔로우한 유저 ID
+     */
+    @Override
+    @Transactional
+    public void saveFollowPost(Long userId, Long targetId) {
+        List<Long> postIdList = jpaPostRepository.findAllPostIdByAuthorId(targetId);
+        List<UserPostQueueEntity> userPostQueueEntityList = postIdList.stream()
+                                                                      .map(postId -> new UserPostQueueEntity(userId, postId, targetId))
+                                                                      .toList();
+        jpaUserPostQueueRepository.saveAll(userPostQueueEntityList);
+    }
+
+    /**
+     * 언팔로우한 유저의 모든 게시물을 현재 유저의 피드 큐에서 제거
+     *
+     * @param userId 현재 유저 ID
+     * @param targetId 언팔로우한 유저 ID
+     */
+    @Override
+    @Transactional
+    public void deleteUnfollowPost(Long userId, Long targetId) {
+        jpaUserPostQueueRepository.deleteAllByUserIdAndAuthorId(userId, targetId);
+    }
+}

--- a/src/main/java/com/app/flashgram/post/repository/post_queue/UserPostQueueQueryRepository.java
+++ b/src/main/java/com/app/flashgram/post/repository/post_queue/UserPostQueueQueryRepository.java
@@ -1,0 +1,9 @@
+package com.app.flashgram.post.repository.post_queue;
+
+import com.app.flashgram.post.ui.dto.GetPostContentResponseDto;
+import java.util.List;
+
+public interface UserPostQueueQueryRepository {
+
+    List<GetPostContentResponseDto> getContentResponse(Long user_id, Long lastPostId);
+}

--- a/src/main/java/com/app/flashgram/post/repository/post_queue/UserPostQueueQueryRepositoryImpl.java
+++ b/src/main/java/com/app/flashgram/post/repository/post_queue/UserPostQueueQueryRepositoryImpl.java
@@ -1,0 +1,97 @@
+package com.app.flashgram.post.repository.post_queue;
+
+import com.app.flashgram.post.repository.entity.like.QLikeEntity;
+import com.app.flashgram.post.repository.entity.post.QPostEntity;
+import com.app.flashgram.post.repository.entity.post.QUserPostQueueEntity;
+import com.app.flashgram.post.ui.dto.GetPostContentResponseDto;
+import com.app.flashgram.user.repository.entity.QUserEntity;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+/**
+ * 유저 피드의 게시물 데이터를 조회하는 UserPostQueueQueryRepository 구현 클래스
+ * 유저 피드에 맞는 게시물 목록을 가져오기 위한 쿼리 처리
+ */
+@Repository
+@RequiredArgsConstructor
+public class UserPostQueueQueryRepositoryImpl implements UserPostQueueQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+    private static final QUserPostQueueEntity userPostQueueEntity = QUserPostQueueEntity.userPostQueueEntity;
+    private static final QPostEntity postEntity = QPostEntity.postEntity;
+    private static final QUserEntity userEntity = QUserEntity.userEntity;
+    private static final QLikeEntity likeEntity = QLikeEntity.likeEntity;
+
+    /**
+     * 유저의 게시물 피드를 조회
+     *
+     * @param userId 조회할 유저의 ID
+     * @param lastContentId 마지막으로 본 게시물의 ID
+     */
+    public List<GetPostContentResponseDto> getContentResponse(Long userId, Long lastContentId) {
+        return queryFactory
+                .select(
+                        Projections.fields(
+                                GetPostContentResponseDto.class,
+                                postEntity.id.as("id"),
+                                postEntity.content.as("content"),
+                                userEntity.id.as("userId"),
+                                userEntity.name.as("userName"),
+                                userEntity.profileImageUrl.as("userProfileImgUrl"),
+                                postEntity.regAt.as("createdAt"),
+                                postEntity.updAt.as("updatedAt"),
+                                postEntity.commentCount.as("commentCount"),
+                                postEntity.likeCount.as("likeCount"),
+                                likeEntity.isNotNull().as("isLikedByMe")
+                        )
+                )
+                .from(userPostQueueEntity)
+                .join(postEntity).on(userPostQueueEntity.postId.eq(postEntity.id))
+                .join(userEntity).on(userPostQueueEntity.authorId.eq(userEntity.id))
+                .leftJoin(likeEntity).on(hasLike(userId))
+                .where(
+                        userPostQueueEntity.userId.eq(userId),
+                        hasLastData(lastContentId)
+                )
+                .orderBy(userPostQueueEntity.postId.desc())
+                .limit(20)
+                .fetch();
+    }
+
+    /**
+     * 유저가 해당 게시물을 좋아요 했는지 여부를 확인하는 조건
+     *
+     * @param userId 유저의 ID
+     * @return 유저가 좋아요한 게시물인지 여부를 판단하는 조건식
+     */
+    private BooleanExpression hasLike(Long userId) {
+        if (userId == null) {
+
+            return null;
+        }
+
+        return postEntity.id
+                .eq(likeEntity.id.targetId)
+                .and(likeEntity.id.targetType.eq("POST"))
+                .and(likeEntity.id.userId.eq(userId));
+    }
+
+    /**
+     * 마지막으로 본 게시물 ID가 존재하면 해당 게시물 ID보다 작은 게시물만 조회하는 조건
+     *
+     * @param lastId 마지막 게시물 ID
+     * @return 마지막 게시물 ID 기준으로 필터링하는 조건식
+     */
+    private BooleanExpression hasLastData(Long lastId) {
+        if (lastId == null) {
+
+            return null;
+        }
+
+        return postEntity.id.lt(lastId);
+    }
+}

--- a/src/main/java/com/app/flashgram/post/repository/post_queue/package-info.java
+++ b/src/main/java/com/app/flashgram/post/repository/post_queue/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * 이 패키지는 내부적으로 게시물 관련 큐(Queue) 기능을 관리하기 위한 패키지
+ *
+ * 서비스 레이어에 직접 노출되지 않도록 하기 위해 repository에서 관리
+ */
+package com.app.flashgram.post.repository.post_queue;

--- a/src/main/java/com/app/flashgram/post/ui/FeedController.java
+++ b/src/main/java/com/app/flashgram/post/ui/FeedController.java
@@ -1,0 +1,37 @@
+package com.app.flashgram.post.ui;
+
+import com.app.flashgram.common.ui.Response;
+import com.app.flashgram.post.repository.post_queue.UserPostQueueQueryRepository;
+import com.app.flashgram.post.ui.dto.GetPostContentResponseDto;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 피드 관련 HTTP 요청을 처리하는 REST 컨트롤러
+ * 유저가 볼 수 있는 게시물 목록을 제공
+ */
+@RestController
+@RequestMapping("/feed")
+@RequiredArgsConstructor
+public class FeedController {
+
+    private final UserPostQueueQueryRepository queueQueryRepository;
+
+    /**
+     * 유저의 게시물 피드를 조회
+     *
+     * @param userId 조회할 유저의 ID
+     * @param lastPostId 마지막으로 본 게시물의 ID (optional)
+     * @return 유저의 게시물 피드를 담은 응답 객체
+     */
+    @GetMapping("/{userId}")
+    public Response<List<GetPostContentResponseDto>> getPostFeed(@PathVariable(name = "userId") Long userId, Long lastPostId) {
+        List<GetPostContentResponseDto> result = queueQueryRepository.getContentResponse(userId, lastPostId);
+
+        return Response.ok(result);
+    }
+}

--- a/src/main/java/com/app/flashgram/post/ui/dto/GetContentResponseDto.java
+++ b/src/main/java/com/app/flashgram/post/ui/dto/GetContentResponseDto.java
@@ -1,0 +1,30 @@
+package com.app.flashgram.post.ui.dto;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+
+/**
+ * 게시물 컨텐츠에 대한 응답 DTO
+ * 게시물의 기본적인 정보(내용, 작성자, 좋아요 수 등)를 포함
+ */
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@SuperBuilder
+public class GetContentResponseDto {
+
+    private Long id;
+    private String content;
+    private Long userId;
+    private String userName;
+    private String userProfileImgUrl;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private Integer likeCount;
+    private boolean isLikedByMe;
+}

--- a/src/main/java/com/app/flashgram/post/ui/dto/GetPostContentResponseDto.java
+++ b/src/main/java/com/app/flashgram/post/ui/dto/GetPostContentResponseDto.java
@@ -1,0 +1,21 @@
+package com.app.flashgram.post.ui.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+
+/**
+ * 게시물 컨텐츠에 대한 응답 DTO (댓글 수 포함)
+ * 게시물 정보에 댓글 수를 추가한 DTO
+ */
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@SuperBuilder
+public class GetPostContentResponseDto extends GetContentResponseDto {
+
+    private Integer commentCount;
+}

--- a/src/main/java/com/app/flashgram/user/repository/UserRelationRepositoryImpl.java
+++ b/src/main/java/com/app/flashgram/user/repository/UserRelationRepositoryImpl.java
@@ -1,5 +1,6 @@
 package com.app.flashgram.user.repository;
 
+import com.app.flashgram.post.repository.post_queue.UserPostQueueCommandRepository;
 import com.app.flashgram.user.application.interfaces.UserRelationRepository;
 import com.app.flashgram.user.domain.User;
 import com.app.flashgram.user.repository.entity.UserEntity;
@@ -22,6 +23,7 @@ public class UserRelationRepositoryImpl implements UserRelationRepository {
 
     private final JpaUserRelationRepository jpaUserRelationRepository;
     private final JpaUserRepository jpaUserRepository;
+    private final UserPostQueueCommandRepository commandRepository;
 
     /**
      * 특정 유저가 다른 유저를 이미 팔로우하고 있는지 확인
@@ -51,6 +53,7 @@ public class UserRelationRepositoryImpl implements UserRelationRepository {
 
         jpaUserRelationRepository.save(entity);
         jpaUserRepository.saveAll(List.of(new UserEntity(user), new UserEntity(targetUser)));
+        commandRepository.saveFollowPost(user.getId(), targetUser.getId());
     }
 
     /**
@@ -67,5 +70,6 @@ public class UserRelationRepositoryImpl implements UserRelationRepository {
 
         jpaUserRelationRepository.deleteById(id);
         jpaUserRepository.saveAll(List.of(new UserEntity(user), new UserEntity(targetUser)));
+        commandRepository.deleteUnfollowPost(user.getId(), targetUser.getId());
     }
 }

--- a/src/main/java/com/app/flashgram/user/repository/entity/UserRelationEntity.java
+++ b/src/main/java/com/app/flashgram/user/repository/entity/UserRelationEntity.java
@@ -18,8 +18,8 @@ import lombok.NoArgsConstructor;
 public class UserRelationEntity extends TimeBaseEntity {
 
     @Id
-    public Long followerUserId;
+    public Long followingUserId;
 
     @Id
-    public Long followingUserId;
+    public Long followerUserId;
 }

--- a/src/main/java/com/app/flashgram/user/repository/entity/UserRelationIdEntity.java
+++ b/src/main/java/com/app/flashgram/user/repository/entity/UserRelationIdEntity.java
@@ -11,6 +11,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class UserRelationIdEntity {
 
-    public Long followerUserId;
     public Long followingUserId;
+    public Long followerUserId;
 }

--- a/src/main/java/com/app/flashgram/user/repository/jpa/JpaUserRelationRepository.java
+++ b/src/main/java/com/app/flashgram/user/repository/jpa/JpaUserRelationRepository.java
@@ -2,8 +2,21 @@ package com.app.flashgram.user.repository.jpa;
 
 import com.app.flashgram.user.repository.entity.UserRelationEntity;
 import com.app.flashgram.user.repository.entity.UserRelationIdEntity;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface JpaUserRelationRepository extends JpaRepository<UserRelationEntity, UserRelationIdEntity> {
 
+    /**
+     * 해당 유저가 팔로우하는 모든 유저의 ID 목록 조회
+     * JPQL을 사용하여 팔로잉 ID만을 선택적으로 조회
+     *
+     * @param userId 팔로워 유저의 ID
+     * @return 해당 유저가 팔로우하는 모든 유저의 ID 리스트
+     */
+    @Query(value = "SELECT u.followingUserId "
+            + "FROM UserRelationEntity u "
+            + "WHERE u.followerUserId = :userId")
+    List<Long> findFollowers(Long userId);
 }


### PR DESCRIPTION
- FeedController: 유저 피드 조회를 위한 API 엔드포인트 구현
- GetContentResponseDto: 게시물 정보 전달을 위한 DTO 클래스 정의
- GetPostContentResponseDto: 댓글 수 추가한 게시물 피드 DTO 클래스 정의

- UserPostQueueEntity: 유저 피드 큐 엔티티 정의
- JpaUserPostQueueRepository: 게시물 피드를 저장하고 조회하는 리포지토리 구현
- UserPostQueueCommandRepository: 피드 큐 관련 데이터 저장 및 삭제 로직 구현
- UserPostQueueCommandRepositoryImpl: 피드 큐에 게시물 저장 및 삭제 로직 구현
- UserPostQueueQueryRepository: 피드 큐 관련 데이터 조회 로직 정의
- UserPostQueueQueryRepositoryImpl: 피드 큐에서 게시물 조회 로직 구현

- UserRelationRepositoryImpl: 팔로우/언팔로우한 유저의 모든 게시물을 현재 유저의 피드 큐에 저장/삭제 추가
- PostRepositoryImpl: 새로운 게시글 작성 시 작성자의 모든 팔로워들의 피드 큐에 발행 추가
- JpaPostRepository: 새로 팔로우한 유저의 모든 게시글 가져오기 추가
- JpaUserRelationRepository: 해당 유저가 팔로우하는 모든 유저의 ID 리스트 찾기 추가

게시글의 댓글 수 기능 추가
- PostEntity: commentCount 컬럼 추가
- JpaPostRepository: increaseCommentCount 추가
- CommentRepositoryImpl: commentCount 로직 추가