### PR TITLE
feat(post): 게시글 좋아요 동시성 처리(업데이트 갱신 유실 방지)

### DIFF
--- a/src/main/java/com/app/flashgram/post/repository/LikeRepositoryImpl.java
+++ b/src/main/java/com/app/flashgram/post/repository/LikeRepositoryImpl.java
@@ -3,9 +3,7 @@ package com.app.flashgram.post.repository;
 import com.app.flashgram.post.appication.interfaces.LikeRepository;
 import com.app.flashgram.post.domain.Post;
 import com.app.flashgram.post.domain.comment.Comment;
-import com.app.flashgram.post.repository.entity.comment.CommentEntity;
 import com.app.flashgram.post.repository.entity.like.LikeEntity;
-import com.app.flashgram.post.repository.entity.post.PostEntity;
 import com.app.flashgram.post.repository.jpa.JpaCommentRepository;
 import com.app.flashgram.post.repository.jpa.JpaLikeRepository;
 import com.app.flashgram.post.repository.jpa.JpaPostRepository;
@@ -60,7 +58,7 @@ public class LikeRepositoryImpl implements LikeRepository {
 
         //jpaLikeRepository.save(new LikeEntity(post, user));
         entityManager.persist(likeEntity);
-        jpaPostRepository.updateLikeCount(new PostEntity(post));
+        jpaPostRepository.updateLikeCount(post.getId(), 1);
     }
 
     /**
@@ -76,7 +74,7 @@ public class LikeRepositoryImpl implements LikeRepository {
         LikeEntity likeEntity = new LikeEntity(post, user);
 
         jpaLikeRepository.deleteById(likeEntity.getId());
-        jpaPostRepository.updateLikeCount(new PostEntity(post));
+        jpaPostRepository.updateLikeCount(post.getId(), -1);
     }
 
     /**
@@ -107,7 +105,7 @@ public class LikeRepositoryImpl implements LikeRepository {
 
         //jpaLikeRepository.save(new LikeEntity(comment, user));
         entityManager.persist(likeEntity);
-        jpaCommentRepository.updateLikeCount(new CommentEntity(comment));
+        jpaCommentRepository.updateLikeCount(comment.getId(), 1);
     }
 
     /**
@@ -123,6 +121,6 @@ public class LikeRepositoryImpl implements LikeRepository {
         LikeEntity likeEntity = new LikeEntity(comment, user);
 
         jpaLikeRepository.deleteById(likeEntity.getId());
-        jpaCommentRepository.updateLikeCount(new CommentEntity(comment));
+        jpaCommentRepository.updateLikeCount(comment.getId(), -1);
     }
 }

--- a/src/main/java/com/app/flashgram/post/repository/jpa/JpaCommentRepository.java
+++ b/src/main/java/com/app/flashgram/post/repository/jpa/JpaCommentRepository.java
@@ -28,12 +28,13 @@ public interface JpaCommentRepository extends JpaRepository<CommentEntity, Long>
      * 댓글의 좋아요 수 업데이트
      * 업데이트 시 수정 시간(updAt)이 현재 시간으로 자동 설정
      *
-     * @param commentEntity 업데이트할 좋아요 수가 담긴 댓글 엔티티
+     * @param commentId
+     * @param likeCount
      */
     @Modifying
     @Query(value = "UPDATE CommentEntity c "
-            + "SET c.likeCount = :#{#commentEntity.likeCount}, "
+            + "SET c.likeCount = c.likeCount + :likeCount, "
             + "c.updAt = now() "
-            + "WHERE c.id = :#{#commentEntity.getId()}")
-    void updateLikeCount(CommentEntity commentEntity);
+            + "WHERE c.id = :commentId")
+    void updateLikeCount(Long commentId, Integer likeCount);
 }

--- a/src/main/java/com/app/flashgram/post/repository/jpa/JpaPostRepository.java
+++ b/src/main/java/com/app/flashgram/post/repository/jpa/JpaPostRepository.java
@@ -30,14 +30,15 @@ public interface JpaPostRepository extends JpaRepository<PostEntity, Long> {
      * 게시물의 좋아요 수 업데이트
      * 업데이트 시 수정 시간(updAt)이 현재 시간으로 자동 설정
      *
-     * @param postEntity 업데이트할 좋아요 수가 담긴 게시물 엔티티
+     * @param postId
+     * @param likeCount
      */
     @Modifying
     @Query(value = "UPDATE PostEntity p "
-            + "SET p.likeCount = :#{#postEntity.likeCount}, "
+            + "SET p.likeCount = p.likeCount + :likeCount, "
             + "p.updAt = now() "
-            + "WHERE p.id = :#{#postEntity.getId()}")
-    void updateLikeCount(PostEntity postEntity);
+            + "WHERE p.id = :postId")
+    void updateLikeCount(Long postId, Integer likeCount);
 
     /**
      * 게시물의 댓글 수를 1 증가시키고 수정 시간 업데이트


### PR DESCRIPTION
- JpaPostRepository: 객체를 직접 업데이트 하는 것이 아닌, 현재 값에 추가 연산하는 것으로 변경
- JpaCommentRepository: 객체를 직접 업데이트 하는 것이 아닌, 현재 값에 추가 연산하는 것으로 변경
- LikeRepositoryImpl: 좋아요/좋아요 취소 파라미터 변경