### PR TITLE
feat(auth): 이메일 검증 및 회원가입 테스트 및 기능 구현

### DIFF
--- a/src/main/java/com/app/flashgram/auth/appliction/AuthService.java
+++ b/src/main/java/com/app/flashgram/auth/appliction/AuthService.java
@@ -1,0 +1,44 @@
+package com.app.flashgram.auth.appliction;
+
+import com.app.flashgram.auth.appliction.dto.CreateUserAuthRequestDto;
+import com.app.flashgram.auth.appliction.interfaces.EmailVerificationRepository;
+import com.app.flashgram.auth.appliction.interfaces.UserAuthRepository;
+import com.app.flashgram.auth.domain.Email;
+import com.app.flashgram.auth.domain.UserAuth;
+import com.app.flashgram.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+/**
+ * 유저 인증 및 회원가입을 처리하는 서비스 클래스
+ * 이메일 인증 및 유저 등록 프로세스 관리
+ */
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final UserAuthRepository userAuthRepository;
+    private final EmailVerificationRepository emailVerificationRepository;
+
+    /**
+     * 유저 등록 메소드
+     *
+     * @param dto 유저 등록에 필요한 정보를 담고 있는 DTO 객체
+     * @return 등록된 유저의 ID
+     * @throws IllegalArgumentException 이메일이 인증되지 않은 경우 발생
+     */
+    public  Long registerUser(CreateUserAuthRequestDto dto){
+        Email email = Email.createEmail(dto.email());
+
+        if (!emailVerificationRepository.isEmailVerified(email)) {
+            throw new IllegalArgumentException("인증되지 않은 이메일입니다.");
+        }
+
+        UserAuth userAuth = new UserAuth(dto.email(), dto.password(), dto.role());
+        User user = new User(dto.name(), dto.profileImgUrl());
+        userAuth = userAuthRepository.registerUser(userAuth, user);
+
+        return userAuth.getUserId();
+    }
+
+}

--- a/src/main/java/com/app/flashgram/auth/appliction/EmailService.java
+++ b/src/main/java/com/app/flashgram/auth/appliction/EmailService.java
@@ -30,4 +30,16 @@ public class EmailService {
         emailSendRepository.sendEmail(email, token);
         emailVerificationRepository.createEmailVerification(email, token);
     }
+
+    /**
+     * 이메일과 토큰을 검증하여 이메일 인증 처리
+     *
+     * @param email 인증할 이메일 주소
+     * @param token 이메일 인증을 위한 토큰
+     */
+    public void verifyEmail(String email, String token) {
+        Email emailValue = Email.createEmail(email);
+
+        emailVerificationRepository.verifyEmail(emailValue, token);
+    }
 }

--- a/src/main/java/com/app/flashgram/auth/appliction/dto/CreateUserAuthRequestDto.java
+++ b/src/main/java/com/app/flashgram/auth/appliction/dto/CreateUserAuthRequestDto.java
@@ -1,0 +1,5 @@
+package com.app.flashgram.auth.appliction.dto;
+
+public record CreateUserAuthRequestDto(String email, String password, String role, String name, String profileImgUrl) {
+
+}

--- a/src/main/java/com/app/flashgram/auth/appliction/interfaces/EmailVerificationRepository.java
+++ b/src/main/java/com/app/flashgram/auth/appliction/interfaces/EmailVerificationRepository.java
@@ -5,4 +5,6 @@ import com.app.flashgram.auth.domain.Email;
 public interface EmailVerificationRepository {
 
     void createEmailVerification(Email email, String token);
+    void verifyEmail(Email email, String token);
+    boolean isEmailVerified(Email email);
 }

--- a/src/main/java/com/app/flashgram/auth/appliction/interfaces/UserAuthRepository.java
+++ b/src/main/java/com/app/flashgram/auth/appliction/interfaces/UserAuthRepository.java
@@ -1,0 +1,9 @@
+package com.app.flashgram.auth.appliction.interfaces;
+
+import com.app.flashgram.auth.domain.UserAuth;
+import com.app.flashgram.user.domain.User;
+
+public interface UserAuthRepository {
+
+    UserAuth registerUser(UserAuth auth, User user);
+}

--- a/src/main/java/com/app/flashgram/auth/domain/Password.java
+++ b/src/main/java/com/app/flashgram/auth/domain/Password.java
@@ -1,0 +1,43 @@
+package com.app.flashgram.auth.domain;
+
+/**
+ * 비밀번호를 관리하는 도메인 클래스
+ * SHA-256 암호화를 사용하여 비밀번호를 저장하고 검증
+ */
+public class Password {
+
+    private final String encryptPassword;
+
+    private Password(String encryptPassword) {
+        this.encryptPassword = encryptPassword;
+    }
+
+    /**
+     * 주어진 평문 비밀번호를 암호화하여 Password 객체 생성
+     *
+     * @param password 평문 비밀번호
+     * @return 암호화된 Password 객체
+     * @throws IllegalArgumentException 비밀번호가 null이거나 빈 문자열인 경우 발생
+     */
+    public static Password creatEncryptPassword(String password) {
+        if (password == null || password.isEmpty()) {
+            throw new IllegalArgumentException("패스워드는 빈 값이 될 수 없습니다.");
+        }
+
+        return new Password(SHA256.encrypt(password));
+    }
+
+    /**
+     * 주어진 평문 비밀번호가 현재 암호화된 비밀번호와 일치하는지 검증
+     *
+     * @param password 검증할 평문 비밀번호
+     * @return 비밀번호 일치 여부
+     */
+    public boolean matchPassword(String password) {
+        return encryptPassword.matches(SHA256.encrypt(password));
+    }
+
+    public String getEncryptPassword() {
+        return encryptPassword;
+    }
+}

--- a/src/main/java/com/app/flashgram/auth/domain/SHA256.java
+++ b/src/main/java/com/app/flashgram/auth/domain/SHA256.java
@@ -1,0 +1,47 @@
+package com.app.flashgram.auth.domain;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+/**
+ * SHA-256 해시 알고리즘을 사용하여 텍스트를 해시화하는 유틸리티 클래스
+ */
+public class SHA256 {
+
+    /**
+     * 주어진 텍스트를 SHA-256 해시로 변환
+     *
+     * @param text 해시를 생성할 원본 텍스트
+     * @return SHA-256 해시 값을 16진수 문자열로 반환
+     * @throws IllegalArgumentException SHA-256 알고리즘을 찾을 수 없는 경우 발생
+     */
+    public static String encrypt(String text) {
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+            md.update(text.getBytes());
+            return byresToHex(md.digest());
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalArgumentException("SHA-256 알고리즘을 찾을 수 없습니다.");
+        }
+    }
+
+    /**
+     * 주어진 바이트 배열을 16진수 문자열로 변환합
+     *
+     * @param bytes 변환할 바이트 배열
+     * @return 변환된 16진수 문자열 반환
+     */
+    private static String byresToHex(byte[] bytes) {
+        StringBuilder sb = new StringBuilder();
+
+        for (byte b : bytes) {
+            sb.append(String.format("%02x", b));
+        }
+
+        return sb.toString();
+    }
+
+    private SHA256() {
+
+    }
+}

--- a/src/main/java/com/app/flashgram/auth/domain/UserAuth.java
+++ b/src/main/java/com/app/flashgram/auth/domain/UserAuth.java
@@ -1,0 +1,43 @@
+package com.app.flashgram.auth.domain;
+
+public class UserAuth {
+
+    private final Email email;
+    private final Password password;
+    private final UserRole userRole;
+    private Long userId;
+
+    public UserAuth(String email, String password, String role) {
+        this.email = Email.createEmail(email);
+        this.password = Password.creatEncryptPassword(password);
+        this.userRole = UserRole.valueOf(role);
+    }
+
+    public UserAuth(String email, String password, String userRole, long userId) {
+        this.email = Email.createEmail(email);
+        this.password = Password.creatEncryptPassword(password);
+        this.userRole = UserRole.valueOf(userRole);
+        this.userId = userId;
+    }
+
+    public String getEmail() {
+
+        return email.getEmailText();
+    }
+
+    public String getPassword() {
+
+        return password.getEncryptPassword();
+    }
+
+    public String getUserRole() {
+
+        return userRole.name();
+    }
+
+    public Long getUserId() {
+
+        return userId;
+    }
+
+}

--- a/src/main/java/com/app/flashgram/auth/domain/UserRole.java
+++ b/src/main/java/com/app/flashgram/auth/domain/UserRole.java
@@ -1,0 +1,5 @@
+package com.app.flashgram.auth.domain;
+
+public enum UserRole {
+    USER, ADMIN
+}

--- a/src/main/java/com/app/flashgram/auth/repositiry/UserAuthRepositoryImpl.java
+++ b/src/main/java/com/app/flashgram/auth/repositiry/UserAuthRepositoryImpl.java
@@ -1,0 +1,41 @@
+package com.app.flashgram.auth.repositiry;
+
+import com.app.flashgram.auth.appliction.interfaces.UserAuthRepository;
+import com.app.flashgram.auth.domain.UserAuth;
+import com.app.flashgram.auth.repositiry.entity.UserAuthEntity;
+import com.app.flashgram.auth.repositiry.jpa.JpaUserAuthRepository;
+import com.app.flashgram.user.application.interfaces.UserRepository;
+import com.app.flashgram.user.domain.User;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+/**
+ * 유저 인증 정보를 관리하는 리포지토리 구현체
+ * JPA를 사용하여 유저 인증 정보를 저장하고 관리
+ */
+@Repository
+@RequiredArgsConstructor
+public class UserAuthRepositoryImpl implements UserAuthRepository {
+
+    private final JpaUserAuthRepository jpaUserAuthRepository;
+    private final UserRepository userRepository;
+
+    /**
+     * 새로운 유저를 등록하고 인증 정보를 저장
+     *
+     * @param auth 유저 인증 정보
+     * @param user 유저 정보
+     * @return 저장된 유저 인증 정보
+     */
+    @Override
+    @Transactional
+    public UserAuth registerUser(UserAuth auth, User user) {
+        User savedUser = userRepository.save(user);
+        UserAuthEntity userAuthEntity = new UserAuthEntity(auth, savedUser.getId());
+
+        userAuthEntity = jpaUserAuthRepository.save(userAuthEntity);
+
+        return userAuthEntity.toUserAuth();
+    }
+}

--- a/src/main/java/com/app/flashgram/auth/repositiry/entity/EmailVerificationEntity.java
+++ b/src/main/java/com/app/flashgram/auth/repositiry/entity/EmailVerificationEntity.java
@@ -25,20 +25,45 @@ public class EmailVerificationEntity extends TimeBaseEntity {
     private boolean isVerified;
 
     public EmailVerificationEntity(String email, String token) {
+        this.id = null;
         this.email = email;
         this.token = token;
         this.isVerified = false;
     }
 
+    /**
+     * 현재 이메일의 인증 완료 여부 반환
+     *
+     * @return 이메일 인증 완료 여부
+     */
     public boolean isVerified() {
         return isVerified;
     }
 
+    /**
+     * 인증 토큰을 새로운 값으로 업데이트
+     *
+     * @param token 새로운 인증 토큰
+     */
     public void updateToken(String token) {
         this.token = token;
     }
 
+    /**
+     * 이메일 인증을 완료 처리
+     * 인증 상태를 true로 변경합니다.
+     */
     public void verify() {
         this.isVerified = true;
+    }
+
+    /**
+     * 주어진 토큰과 현재 저장된 토큰이 일치하는지 확인
+     *
+     * @param token 검증할 토큰
+     * @return 토큰 일치 여부
+     */
+    public boolean hasSameToken(String token) {
+        return this.token.equals(token);
     }
 }

--- a/src/main/java/com/app/flashgram/auth/repositiry/entity/UserAuthEntity.java
+++ b/src/main/java/com/app/flashgram/auth/repositiry/entity/UserAuthEntity.java
@@ -1,0 +1,36 @@
+package com.app.flashgram.auth.repositiry.entity;
+
+import com.app.flashgram.auth.domain.UserAuth;
+import com.app.flashgram.common.repository.entity.TimeBaseEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "fg_user_auth")
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class UserAuthEntity extends TimeBaseEntity {
+
+    @Id
+    private String email;
+    private String password;
+    private String role;
+    private Long userId;
+
+    public UserAuthEntity(UserAuth userAuth, Long userId) {
+        this.email = userAuth.getEmail();
+        this.password = userAuth.getPassword();
+        this.role = userAuth.getUserRole();
+        this.userId = userId;
+    }
+
+    public UserAuth toUserAuth() {
+
+        return new UserAuth(email, password, role, userId);
+    }
+}

--- a/src/main/java/com/app/flashgram/auth/repositiry/jpa/JpaEmailVerificationRepository.java
+++ b/src/main/java/com/app/flashgram/auth/repositiry/jpa/JpaEmailVerificationRepository.java
@@ -1,0 +1,10 @@
+package com.app.flashgram.auth.repositiry.jpa;
+
+import com.app.flashgram.auth.repositiry.entity.EmailVerificationEntity;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JpaEmailVerificationRepository extends JpaRepository<EmailVerificationEntity, Long> {
+
+    Optional<EmailVerificationEntity> findByEmail(String email);
+}

--- a/src/main/java/com/app/flashgram/auth/repositiry/jpa/JpaUserAuthRepository.java
+++ b/src/main/java/com/app/flashgram/auth/repositiry/jpa/JpaUserAuthRepository.java
@@ -1,0 +1,8 @@
+package com.app.flashgram.auth.repositiry.jpa;
+
+import com.app.flashgram.auth.repositiry.entity.UserAuthEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JpaUserAuthRepository extends JpaRepository<UserAuthEntity, String> {
+
+}

--- a/src/main/java/com/app/flashgram/auth/ui/SignUpController.java
+++ b/src/main/java/com/app/flashgram/auth/ui/SignUpController.java
@@ -1,9 +1,12 @@
 package com.app.flashgram.auth.ui;
 
+import com.app.flashgram.auth.appliction.AuthService;
 import com.app.flashgram.auth.appliction.EmailService;
+import com.app.flashgram.auth.appliction.dto.CreateUserAuthRequestDto;
 import com.app.flashgram.auth.appliction.dto.SendEmailRequestDto;
 import com.app.flashgram.common.ui.Response;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -17,7 +20,8 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class SignUpController {
 
-    public final EmailService emailService;
+    private final EmailService emailService;
+    private final AuthService authService;
 
     /**
      * 회원가입 인증 이메일 전송
@@ -30,5 +34,30 @@ public class SignUpController {
         emailService.sendEmail(dto);
 
         return Response.ok(null);
+    }
+
+    /**
+     * 이메일 인증 토큰 검증
+     *
+     * @param email 인증할 이메일 주소
+     * @param token 이메일 인증을 위한 토큰
+     * @return Response 객체
+     */
+    @GetMapping("/verify-token")
+    public Response<Void> verifyEmail(String email, String token) {
+        emailService.verifyEmail(email, token);
+
+        return Response.ok(null);
+    }
+
+    /**
+     * 회원가입 요청을 처리하고 유저를 등록
+     *
+     * @param dto 회원가입에 필요한 정보를 담은 DTO
+     * @return Response 객체. 성공 시 등록된 유저 ID 반환
+     */
+    @PostMapping("/register")
+    public Response<Long> register(@RequestBody CreateUserAuthRequestDto dto) {
+        return Response.ok(authService.registerUser(dto));
     }
 }

--- a/src/main/java/com/app/flashgram/user/domain/User.java
+++ b/src/main/java/com/app/flashgram/user/domain/User.java
@@ -36,6 +36,10 @@ public class User {
         this.followerCounter = new PositiveIntegerCounter();
     }
 
+    public User(String name, String profileImgUrl) {
+        this(null, new UserInfo(name, profileImgUrl));
+    }
+
     /**
      * 지정된 유저 팔로우
      * 팔로우 시 자신의 팔로잉 수와 대상 유저의 팔로워 수가 증가

--- a/src/test/java/com/app/flashgram/FlashgramApplicationTests.java
+++ b/src/test/java/com/app/flashgram/FlashgramApplicationTests.java
@@ -1,13 +1,8 @@
 package com.app.flashgram;
 
-import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
 class FlashgramApplicationTests {
-
-	@Test
-	void contextLoads() {
-	}
 
 }

--- a/src/test/java/com/app/flashgram/acceptance/auth/SignUpAcceptanceTest.java
+++ b/src/test/java/com/app/flashgram/acceptance/auth/SignUpAcceptanceTest.java
@@ -1,10 +1,15 @@
 package com.app.flashgram.acceptance.auth;
 
+import static com.app.flashgram.acceptance.steps.SignUpAcceptanceSteps.registerUser;
 import static com.app.flashgram.acceptance.steps.SignUpAcceptanceSteps.requestSendEmail;
+import static com.app.flashgram.acceptance.steps.SignUpAcceptanceSteps.requestVerifyEmail;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.app.flashgram.acceptance.utils.AcceptanceTestTemplate;
+import com.app.flashgram.auth.appliction.dto.CreateUserAuthRequestDto;
 import com.app.flashgram.auth.appliction.dto.SendEmailRequestDto;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -40,6 +45,91 @@ class SignUpAcceptanceTest extends AcceptanceTestTemplate {
 
         //when
         Integer code = requestSendEmail(dto);
+
+        //then
+        assertEquals(400, code);
+    }
+
+    @Test
+    void givenSendEmail_whenVerifyEmail_thenEmailVerified() {
+        //given
+        requestSendEmail(new SendEmailRequestDto(email));
+
+        //when
+        String token = getEmailToken(email);
+        Integer code = requestVerifyEmail(email, token);
+
+        //then
+        boolean isEmailVerified = isEmailVerified(email);
+        assertEquals(0, code);
+        assertTrue(isEmailVerified);
+    }
+
+    @Test
+    void givenSendEmail_whenVerifyEmailWithWrongToken_thenEmailNotVerified() {
+        //given
+        requestSendEmail(new SendEmailRequestDto(email));
+
+        //when
+        Integer code = requestVerifyEmail(email, "wrong token");
+
+        //then
+        boolean isEmailVerified = isEmailVerified(email);
+        assertEquals(400, code);
+        assertFalse(isEmailVerified);
+    }
+
+    @Test
+    void givenSendEmailVerified_whenVerifyAgain_thenThrowError() {
+        //given
+        requestSendEmail(new SendEmailRequestDto(email));
+        String token = getEmailToken(email);
+        requestVerifyEmail(email, token);
+
+        //when
+        Integer code = requestVerifyEmail(email, token);
+
+        //then
+        assertEquals(400, code);
+    }
+
+    @Test
+    void givenSendEmail_whenVerifyEmailWithWrongEmaill_thenThrowError() {
+        //given
+        requestSendEmail(new SendEmailRequestDto(email));
+
+        //when
+        Integer code = requestVerifyEmail("wrong email", "token");
+
+        //then
+        assertEquals(400, code);
+    }
+
+    @Test
+    void givenVerifiedEmail_whenRegister_thenUserRegistered() {
+        //given
+        requestSendEmail(new SendEmailRequestDto(email));
+        String token = getEmailToken(email);
+        requestVerifyEmail(email, token);
+
+        //when
+        CreateUserAuthRequestDto dto = new CreateUserAuthRequestDto(email, "password", "USER", "name", "profileImgUrl");
+        Integer code = registerUser(dto);
+
+        //then
+        assertEquals(0, code);
+        Long userId = getUserId(email);
+        assertEquals(1L, userId);
+    }
+
+    @Test
+    void givenVerifiedEmail_whenRegister_thenThrowError() {
+        //given
+        requestSendEmail(new SendEmailRequestDto(email));
+
+        //when
+        CreateUserAuthRequestDto dto = new CreateUserAuthRequestDto(email, "password", "USER", "name", "profileImgUrl");
+        Integer code = registerUser(dto);
 
         //then
         assertEquals(400, code);

--- a/src/test/java/com/app/flashgram/acceptance/steps/SignUpAcceptanceSteps.java
+++ b/src/test/java/com/app/flashgram/acceptance/steps/SignUpAcceptanceSteps.java
@@ -1,5 +1,6 @@
 package com.app.flashgram.acceptance.steps;
 
+import com.app.flashgram.auth.appliction.dto.CreateUserAuthRequestDto;
 import com.app.flashgram.auth.appliction.dto.SendEmailRequestDto;
 import io.restassured.RestAssured;
 import org.springframework.http.MediaType;
@@ -13,6 +14,30 @@ public class SignUpAcceptanceSteps {
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .when()
                 .post("/signup/send-verification-email")
+                .then()
+                .extract()
+                .jsonPath().get("code");
+    }
+
+    public static Integer requestVerifyEmail(String email, String token) {
+        return RestAssured
+                .given()
+                .queryParam("email", email)
+                .queryParam("token", token)
+                .when()
+                .get("/signup/verify-token")
+                .then()
+                .extract()
+                .jsonPath().get("code");
+    }
+
+    public static Integer registerUser(CreateUserAuthRequestDto dto) {
+        return RestAssured
+                .given()
+                .body(dto)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .post("/signup/register")
                 .then()
                 .extract()
                 .jsonPath().get("code");

--- a/src/test/java/com/app/flashgram/acceptance/utils/AcceptanceTestTemplate.java
+++ b/src/test/java/com/app/flashgram/acceptance/utils/AcceptanceTestTemplate.java
@@ -29,4 +29,12 @@ public class AcceptanceTestTemplate {
     protected String getEmailToken(String email) {
         return loader.getEmailToken(email);
     }
+
+    protected boolean isEmailVerified(String email) {
+        return loader.isEmailVerified(email);
+    }
+
+    protected Long getUserId(String email) {
+        return loader.getUserId(email);
+    }
 }

--- a/src/test/java/com/app/flashgram/acceptance/utils/DataLoader.java
+++ b/src/test/java/com/app/flashgram/acceptance/utils/DataLoader.java
@@ -32,4 +32,16 @@ public class DataLoader {
                 .getSingleResult()
                 .toString();
     }
+
+    public boolean isEmailVerified(String email) {
+        return entityManager.createQuery("SELECT isVerified FROM EmailVerificationEntity WHERE email = :email", Boolean.class)
+                .setParameter("email", email)
+                .getSingleResult();
+    }
+
+    public Long getUserId(String email) {
+        return entityManager.createQuery("SELECT userId FROM UserAuthEntity WHERE email = :email", Long.class)
+                            .setParameter("email", email)
+                            .getSingleResult();
+    }
 }

--- a/src/test/java/com/app/flashgram/acceptance/utils/DatabaseCleanUp.java
+++ b/src/test/java/com/app/flashgram/acceptance/utils/DatabaseCleanUp.java
@@ -29,7 +29,7 @@ public class DatabaseCleanUp implements InitializingBean {
                 .map(entry -> entry.getJavaType().getAnnotation(Table.class).name())
                 .toList();
 
-        notGeneratedTableNames = List.of("fg_user_relation", "fg_like");
+        notGeneratedTableNames = List.of("fg_user_auth", "fg_user_relation", "fg_like");
     }
 
     @Transactional

--- a/src/test/java/com/app/flashgram/auth/PasswordTest.java
+++ b/src/test/java/com/app/flashgram/auth/PasswordTest.java
@@ -1,0 +1,33 @@
+package com.app.flashgram.auth;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.app.flashgram.auth.domain.Password;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+
+class PasswordTest {
+
+    @Test
+    void givePassword_whenMatchSamePassword_thenReturnTrue() {
+        Password password = Password.creatEncryptPassword("password");
+
+        assertTrue(password.matchPassword("password"));
+    }
+
+    @Test
+    void givePassword_whenMatchDifferentPassword_thenReturnFalse() {
+        Password password = Password.creatEncryptPassword("password1");
+
+        assertFalse(password.matchPassword("password"));
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    void givePasswordIsNull_thenThrowError(String password) {
+        assertThrows(IllegalArgumentException.class, () -> Password.creatEncryptPassword(password));
+    }
+}


### PR DESCRIPTION
- SignUpController: 이메일 검증 및 회원가입을 처리하는 컨트롤러 구현
- EmailService: 이메일과 토큰을 검증하여 이메일 인증 처리
- EmailVerificationRepository: 이메일 및 토큰 인증
- EmailVerificationRepositoryImpl: 이메일 및 토큰 검증 인증 메서드 구현
- EmailVerificationEntity: 주어진 토큰과 현재 객체의 토큰이 같은지 비교하는 메서드 추가
- CreateUserAuthRequestDto: 유저 회원가입 정보 요청 전송 객체
- UserRole: 유저 역할 구분

- Password: 이메일, 패스워드, 권한을 포함하는 사용자 인증 도메인 클래스 추가
- SHA256: 비밀번호 암호화 및 해싱을 위한 유틸리티 클래스 추가

- UserAuth: 이메일, 패스워드, 권한 Mashup 클래스
- UserAuthEntity: 유저 인증 엔티티 클래스 추가
- UserAuthRepository: 유저 인증 정보를 관리하는 인터페이스 정의
- JpaUserAuthRepository: JPA 기반의 유저 인증 정보 저장소 인터페이스 추가
- AuthService: 회원가입 및 사용자 인증 관련 비즈니스 로직을 처리하는 서비스 구현

- JpaEmailVerificationRepository: 이메일 인증 정보를 관리하는 JPA Repository

테스트
- SignUpAcceptanceTest: 이메일 인증 정상 및 예외 케이스 검증, 회원가입
- SignUpAcceptanceSteps: 이메일 인증 검증, 회원가입 테스트 추가

- PasswordTest: 비밀번호 암호화 및 검증 테스트 추가

- DataLoader: 이메일 인증 상태 확인 메서드 추가
- AcceptanceTestTemplate: 이메일 인증 상태 확인을 위해 메서드 호출