### PR TITLE
feat(idempotency): API 요청 멱등성 처리 기능 구현

### DIFF
--- a/src/main/java/com/app/flashgram/common/idempotency/Idempotency.java
+++ b/src/main/java/com/app/flashgram/common/idempotency/Idempotency.java
@@ -1,0 +1,18 @@
+package com.app.flashgram.common.idempotency;
+
+import com.app.flashgram.common.ui.Response;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+
+/**
+ * 멱등성 작업을 나타내는 클래스로, 작업의 키와 응답 포함
+ * 멱등성 요청의 결과를 저장하고 추적하는데 사용
+ */
+@Getter
+@AllArgsConstructor
+public class Idempotency {
+
+    private final String key;
+    private final Response<?> response;
+}

--- a/src/main/java/com/app/flashgram/common/idempotency/IdempotencyAspect.java
+++ b/src/main/java/com/app/flashgram/common/idempotency/IdempotencyAspect.java
@@ -1,0 +1,54 @@
+package com.app.flashgram.common.idempotency;
+
+import com.app.flashgram.common.ui.Response;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+
+/**
+ * 멱등성을 처리하기 위한 AOP Aspect 클래스
+ * {@code @Idempotent} 어노테이션이 적용된 메서드에 대해 멱등성 보장
+ */
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class IdempotencyAspect {
+
+    private final IdempotencyRepository idempotencyRepository;
+    private final HttpServletRequest request;
+
+    /**
+     * {@code @Idempotent} 어노테이션이 적용된 메서드의 실행을 가로채서 멱등성 검사 및 처리
+     * 요청 헤더에서 'Idempotency-Key'를 확인하여 중복 요청 처리
+     *
+     * @param joinPoint AOP 조인 포인트
+     * @return 메서드 실행 결과 또는 저장된 이전 응답
+     * @throws Throwable 메서드 실행 중 발생할 수 있는 예외
+     */
+    @Around("@annotation(Idempotent)")
+    public Object checkIdempotency(ProceedingJoinPoint joinPoint) throws Throwable {
+        String idempotencyKey = request.getHeader("Idempotency-Key");
+
+        if (idempotencyKey == null) {
+
+            return joinPoint.proceed();
+        }
+
+        Idempotency idempotency = idempotencyRepository.getByKey(idempotencyKey);
+
+        if (idempotency != null) {
+
+            return idempotency.getResponse();
+        }
+
+        Object result = joinPoint.proceed();
+
+        Idempotency newIdempotency = new Idempotency(idempotencyKey, (Response<?>) result);
+        idempotencyRepository.save(newIdempotency);
+
+        return result;
+    }
+}

--- a/src/main/java/com/app/flashgram/common/idempotency/IdempotencyRepository.java
+++ b/src/main/java/com/app/flashgram/common/idempotency/IdempotencyRepository.java
@@ -1,0 +1,7 @@
+package com.app.flashgram.common.idempotency;
+
+public interface IdempotencyRepository {
+
+    Idempotency getByKey(String key);
+    void save(Idempotency idempotency);
+}

--- a/src/main/java/com/app/flashgram/common/idempotency/Idempotent.java
+++ b/src/main/java/com/app/flashgram/common/idempotency/Idempotent.java
@@ -1,0 +1,18 @@
+package com.app.flashgram.common.idempotency;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * 멱등성을 보장해야 하는 메서드에 표시하는 어노테이션
+ * 이 어노테이션이 적용된 메서드는 동일한 요청이 여러 번 실행되더라도
+ * 부작용 없이 항상 동일한 결과를 반환하도록 보장
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Idempotent {
+
+
+}

--- a/src/main/java/com/app/flashgram/common/idempotency/repository/IdempotencyRepositoryImpl.java
+++ b/src/main/java/com/app/flashgram/common/idempotency/repository/IdempotencyRepositoryImpl.java
@@ -1,0 +1,42 @@
+package com.app.flashgram.common.idempotency.repository;
+
+import com.app.flashgram.common.idempotency.Idempotency;
+import com.app.flashgram.common.idempotency.IdempotencyRepository;
+import com.app.flashgram.common.idempotency.repository.entity.IdempotencyEntity;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+/**
+ * IdempotencyRepository 인터페이스의 구현체
+ * JPA를 사용하여 멱등성 데이터를 저장 및 조회
+ */
+@Repository
+@RequiredArgsConstructor
+public class IdempotencyRepositoryImpl implements IdempotencyRepository {
+
+    private final JpaIdempotencyRepository jpaIdempotencyRepository;
+
+    /**
+     * 주어진 키에 해당하는 멱등성 데이터 조회
+     *
+     * @param key 조회할 멱등성 키
+     * @return 찾은 Idempotency 객체, 없을 경우 null
+     */
+    @Override
+    public Idempotency getByKey(String key) {
+        Optional<IdempotencyEntity> idempotencyEntity = jpaIdempotencyRepository.findByIdempotencyKey(key);
+
+        return idempotencyEntity.map(IdempotencyEntity::toIdempotency).orElse(null);
+    }
+
+    /**
+     * 멱등성 데이터 저장
+     *
+     * @param idempotency 저장할 Idempotency 객체
+     */
+    @Override
+    public void save(Idempotency idempotency) {
+        jpaIdempotencyRepository.save(new IdempotencyEntity(idempotency));
+    }
+}

--- a/src/main/java/com/app/flashgram/common/idempotency/repository/JpaIdempotencyRepository.java
+++ b/src/main/java/com/app/flashgram/common/idempotency/repository/JpaIdempotencyRepository.java
@@ -1,0 +1,10 @@
+package com.app.flashgram.common.idempotency.repository;
+
+import com.app.flashgram.common.idempotency.repository.entity.IdempotencyEntity;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JpaIdempotencyRepository extends JpaRepository<IdempotencyEntity, Long> {
+
+    Optional<IdempotencyEntity> findByIdempotencyKey(String key);
+}

--- a/src/main/java/com/app/flashgram/common/idempotency/repository/entity/IdempotencyEntity.java
+++ b/src/main/java/com/app/flashgram/common/idempotency/repository/entity/IdempotencyEntity.java
@@ -1,0 +1,54 @@
+package com.app.flashgram.common.idempotency.repository.entity;
+
+import com.app.flashgram.common.idempotency.Idempotency;
+import com.app.flashgram.common.utils.ResponseObjectMapper;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 멱등성 정보를 저장하기 위한 엔티티 클래스
+ */
+@Entity
+@Table(name = "fg_idempotency")
+@NoArgsConstructor
+@AllArgsConstructor
+public class IdempotencyEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(unique = true, nullable = false)
+    private String idempotencyKey;
+
+    @Getter
+    @Column(nullable = false)
+    private String response;
+
+    /**
+     * Idempotency 객체로부터 엔티티 생성
+     *
+     * @param idempotency 변환할 Idempotency 객체
+     */
+    public IdempotencyEntity(Idempotency idempotency) {
+        this.idempotencyKey = idempotency.getKey();
+        this.response = ResponseObjectMapper.toStringResponse(idempotency.getResponse());
+    }
+
+    /**
+     * 엔티티를 Idempotency 객체로 변환
+     *
+     * @return 변환된 Idempotency 객체
+     */
+    public Idempotency toIdempotency() {
+
+        return new Idempotency(this.idempotencyKey, ResponseObjectMapper.toResponseObject(response));
+    }
+}

--- a/src/main/java/com/app/flashgram/common/utils/ResponseObjectMapper.java
+++ b/src/main/java/com/app/flashgram/common/utils/ResponseObjectMapper.java
@@ -1,0 +1,49 @@
+package com.app.flashgram.common.utils;
+
+import com.app.flashgram.common.ui.Response;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+
+/**
+ * Response 객체와 문자열 간의 변환을 처리하는 유틸리티 클래스
+ * Jackson ObjectMapper를 사용하여 직렬화와 역직렬화 수행
+ */
+public class ResponseObjectMapper {
+
+    private ResponseObjectMapper() {
+
+    }
+
+    private static final ObjectMapper objMapper = new ObjectMapper();
+
+    /**
+     * 문자열을 Response 객체로 변환
+     *
+     * @param response JSON 형식의 문자열
+     * @return 변환된 Response 객체, 변환 실패 시 null
+     */
+    public static Response toResponseObject(String response) {
+        try {
+
+            return objMapper.readValue(response, Response.class);
+        } catch (IOException e) {
+
+            return null;
+        }
+    }
+
+    /**
+     * Response 객체를 JSON 문자열로 변환
+     *
+     * @param response 변환할 Response 객체
+     * @return JSON 형식의 문자열, 변환 실패 시 null
+     */
+    public static String toStringResponse(Response<?> response) {
+        try {
+            return objMapper.writeValueAsString(response);
+        } catch (IOException e) {
+
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/app/flashgram/post/ui/CommentController.java
+++ b/src/main/java/com/app/flashgram/post/ui/CommentController.java
@@ -1,5 +1,6 @@
 package com.app.flashgram.post.ui;
 
+import com.app.flashgram.common.idempotency.Idempotent;
 import com.app.flashgram.common.principal.AuthPrincipal;
 import com.app.flashgram.common.principal.UserPrincipal;
 import com.app.flashgram.common.ui.Response;
@@ -39,6 +40,7 @@ public class CommentController {
      * @param dto 댓글 생성에 필요한 정보를 담은 DTO
      * @return 생성된 댓글의 ID
      */
+    @Idempotent
     @PostMapping
     public Response<Long> createComment(@RequestBody CreateCommentRequestDto dto) {
         Comment comment = commentService.createComment(dto);
@@ -53,6 +55,7 @@ public class CommentController {
      * @param dto 댓글 수정에 필요한 정보를 담은 DTO
      * @return 수정된 댓글의 ID
      */
+    @Idempotent
     @PatchMapping("/{commentId}")
     public Response<Long> updateComment(@PathVariable(name = "commentId") Long commentId, @RequestBody UpdateCommentRequestDto dto) {
         Comment comment = commentService.updateComment(commentId, dto);
@@ -66,6 +69,7 @@ public class CommentController {
      * @param dto 좋아요 추가에 필요한 정보를 담은 DTO
      * @return void 응답
      */
+    @Idempotent
     @PostMapping("/like")
     public Response<Void> likeComment(@RequestBody LikeRequestDto dto) {
         commentService.likeComment(dto);
@@ -79,6 +83,7 @@ public class CommentController {
      * @param dto 좋아요 취소에 필요한 정보를 담은 DTO
      * @return void 응답
      */
+    @Idempotent
     @PostMapping("/unlike")
     public Response<Void> unlikeComment(@RequestBody LikeRequestDto dto) {
         commentService.unlikeComment(dto);

--- a/src/main/java/com/app/flashgram/post/ui/PostController.java
+++ b/src/main/java/com/app/flashgram/post/ui/PostController.java
@@ -1,5 +1,6 @@
 package com.app.flashgram.post.ui;
 
+import com.app.flashgram.common.idempotency.Idempotent;
 import com.app.flashgram.common.ui.Response;
 import com.app.flashgram.post.appication.PostService;
 import com.app.flashgram.post.appication.dto.CreatePostRequestDto;
@@ -31,6 +32,7 @@ public class PostController {
      * @param dto 게시물 생성에 필요한 정보를 담은 DTO
      * @return 생성된 게시물의 ID
      */
+    @Idempotent
     @PostMapping
     public Response<Long> createPost(@RequestBody CreatePostRequestDto dto) {
         Post post = postService.createPost(dto);
@@ -45,6 +47,7 @@ public class PostController {
      * @param dto 게시물 수정에 필요한 정보를 담은 DTO
      * @return 수정된 게시물의 ID
      */
+    @Idempotent
     @PatchMapping("/{postId}")
     public Response<Long> updatePost(@PathVariable(name = "postId") Long postId, @RequestBody UpdatePostRequestDto dto) {
         Post post = postService.updatePost(postId, dto);
@@ -59,6 +62,7 @@ public class PostController {
      * @param dto 좋아요할 게시물과 유저 정보를 담은 DTO
      * @return 응답 객체 (데이터 없음)
      */
+    @Idempotent
     @PostMapping("/like")
     public Response<Void> likePost(@RequestBody LikeRequestDto dto) {
         postService.likePost(dto);
@@ -73,6 +77,7 @@ public class PostController {
      * @param dto 좋아요를 취소할 게시물과 유저 정보를 담은 DTO
      * @return 응답 객체 (데이터 없음)
      */
+    @Idempotent
     @PostMapping("/unlike")
     public Response<Void> unlikePost(@RequestBody LikeRequestDto dto) {
         postService.unlikePost(dto);

--- a/src/main/java/com/app/flashgram/user/ui/UserController.java
+++ b/src/main/java/com/app/flashgram/user/ui/UserController.java
@@ -1,5 +1,6 @@
 package com.app.flashgram.user.ui;
 
+import com.app.flashgram.common.idempotency.Idempotent;
 import com.app.flashgram.common.ui.Response;
 import com.app.flashgram.user.application.UserService;
 import com.app.flashgram.user.application.dto.CreateUserRequestDto;
@@ -35,6 +36,7 @@ public class UserController {
      * @param dto 유저 생성에 필요한 정보를 담은 DTO
      * @return 생성된 유저의 ID
      */
+    @Idempotent
     @PostMapping
     public Response<Long> createUser(@RequestBody CreateUserRequestDto dto) {
         User user = userService.createUser(dto);

--- a/src/main/java/com/app/flashgram/user/ui/UserRelationController.java
+++ b/src/main/java/com/app/flashgram/user/ui/UserRelationController.java
@@ -1,5 +1,6 @@
 package com.app.flashgram.user.ui;
 
+import com.app.flashgram.common.idempotency.Idempotent;
 import com.app.flashgram.common.ui.Response;
 import com.app.flashgram.user.application.UserRelationService;
 import com.app.flashgram.user.application.dto.FollowUserRequestDto;
@@ -27,6 +28,7 @@ public class UserRelationController {
      * @param dto 팔로우할 유저와 팔로우를 요청하는 유저의 정보를 담은 DTO
      * @return 응답 객체 (데이터 없음)
      */
+    @Idempotent
     @PostMapping("/follow")
     public Response<Void> followUser(@RequestBody FollowUserRequestDto dto) {
         relationService.follow(dto);
@@ -41,6 +43,7 @@ public class UserRelationController {
      * @param dto 언팔로우할 유저와 언팔로우를 요청하는 유저의 정보를 담은 DTO
      * @return 응답 객체 (데이터 없음)
      */
+    @Idempotent
     @PostMapping("/unfollow")
     public Response<Void> unfollowUser(@RequestBody FollowUserRequestDto dto) {
         relationService.unfollow(dto);


### PR DESCRIPTION
- idempotent: 멱등성 처리를 위한 메서드 어노테이션 추가
- Idempotency: 멱등성 요청과 응답을 담는 도메인 객체 구현
- IdempotencyAspect: 멱등성 처리를 위한 AOP Aspect 구현
- IdempotencyRepository: 멱등성 데이터 저장소 인터페이스 정의
- IdempotencyRepositoryImpl: JPA 기반 멱등성 저장소 구현체 추가
- IdempotencyEntity: 멱등성 데이터 영속화를 위한 엔티티 클래스 구현
- ResponseObjectMapper: 응답 객체와 문자열 간 변환 유틸리티 추가
- JpaIdempotencyRepository: 멱등성 엔티티를 위한 JPA 리포지토리 인터페이스 추가